### PR TITLE
HotLoader integration #48

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "phantomjs-polyfill-object-assign": "0.0.2",
     "phantomjs-prebuilt": "^2.1.13",
     "react-addons-test-utils": "15.2.1",
+    "react-hot-loader": "^1.3.0",
     "redux-mock-store": "^1.2.1",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,17 @@ var basePath = __dirname;
 module.exports = {
   context: path.join(basePath, "src"),
 	resolve: {
-	      extensions: ['', '.js','.ts', '.tsx']
+	      extensions: ['', '.js','.ts', '.tsx'],
+        // Temporary workaround for React-Hot-Loading V1, til we migrate to 3
+        // https://github.com/gaearon/react-hot-loader/issues/417
+        //alias: { 'react/lib/ReactMount': 'react-dom/lib/ReactMount' }
 	},
 	entry: {
-    app: "./index.tsx",
+    app: [
+      "webpack-dev-server/client?http://localhost:8080",
+      "webpack/hot/only-dev-server",
+      "./index.tsx"
+    ],
     vendor: [
              "react",
              "react-dom",
@@ -34,6 +41,7 @@ module.exports = {
   devServer: {
        contentBase: './dist', //Content base
        inline: true, //Enable watch and live reload
+       hot: true,
        noInfo: true,
        host: 'localhost',
        port: 8080,
@@ -45,7 +53,7 @@ module.exports = {
 		loaders: [
 			{
 	      test: /\.(ts|tsx)$/,
-	      loader: 'ts-loader'
+	      loaders: ['react-hot', 'ts-loader']
       },
       {
         test: /\.css$/,
@@ -72,6 +80,7 @@ module.exports = {
 		]
 	},
 	plugins:[
+    new webpack.HotModuleReplacementPlugin(),
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
      new ExtractTextPlugin('[name].css'),
     //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin


### PR DESCRIPTION
This implementation works fine when it's adding Redux-Router support.
Note: In the webpack.config.js file the alias: { 'react/lib/ReactMount': 'react-dom/lib/ReactMount' }, we don't need to use it.